### PR TITLE
Add admin features and security

### DIFF
--- a/src/main/java/com/example/pizzaapp/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/pizzaapp/config/WebSecurityConfig.java
@@ -22,7 +22,7 @@ public class WebSecurityConfig {
                                                 .requestMatchers("/", "/error", "/cart", "/menu", "/css/**", "/js/**",
                                                                 "/assets/**", "/images/**", "/login", "/register")
                                                 .permitAll()
-                                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                                .requestMatchers("/admin/**", "/api/admin/**").hasRole("ADMIN")
                                                 .anyRequest().authenticated())
                                 .formLogin(form -> form
                                                 .loginPage("/login")

--- a/src/main/java/com/example/pizzaapp/controllers/AdminController.java
+++ b/src/main/java/com/example/pizzaapp/controllers/AdminController.java
@@ -1,0 +1,104 @@
+package com.example.pizzaapp.controllers;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.example.pizzaapp.dtos.OrderSummaryDto;
+import com.example.pizzaapp.dtos.UserSummaryDto;
+import com.example.pizzaapp.models.OrderStatus.OrderStatusEnum;
+import com.example.pizzaapp.models.User;
+import com.example.pizzaapp.services.OrderService;
+import com.example.pizzaapp.services.UserService;
+
+@Controller
+@RequestMapping("/admin")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+
+    private final UserService userService;
+    private final OrderService orderService;
+    private final PasswordEncoder passwordEncoder;
+
+    public AdminController(UserService userService, OrderService orderService, PasswordEncoder passwordEncoder) {
+        this.userService = userService;
+        this.orderService = orderService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @GetMapping("/dashboard")
+    public String dashboard() {
+        return "admin/adminDashboard";
+    }
+
+    @GetMapping("/users")
+    public String listUsers(Model model) {
+        List<UserSummaryDto> users = userService.getAllUserSummaries();
+        model.addAttribute("users", users);
+        return "admin/users";
+    }
+
+    @GetMapping("/users/{id}/orders")
+    public String userOrders(@PathVariable UUID id, Model model) {
+        User user = userService.findById(id);
+        if (user == null) {
+            return "pages/error/404";
+        }
+        List<OrderSummaryDto> orders = orderService.getUserOrderSummaries(user);
+        model.addAttribute("user", user);
+        model.addAttribute("orders", orders);
+        return "admin/userOrders";
+    }
+
+    @GetMapping("/users/{id}/changePassword")
+    public String changePasswordForm(@PathVariable UUID id, Model model) {
+        User user = userService.findById(id);
+        if (user == null) {
+            return "pages/error/404";
+        }
+        model.addAttribute("userId", user.getId());
+        return "admin/changeUserPassword";
+    }
+
+    @PostMapping("/users/changePassword")
+    public String changePassword(@RequestParam UUID userId,
+                                 @RequestParam String newPassword,
+                                 @RequestParam String confirmPassword,
+                                 RedirectAttributes redirectAttributes) {
+        if (!newPassword.equals(confirmPassword)) {
+            redirectAttributes.addFlashAttribute("error", "Passwords do not match");
+            return "redirect:/admin/users/" + userId + "/changePassword";
+        }
+        User user = userService.findById(userId);
+        if (user == null) {
+            return "pages/error/404";
+        }
+        userService.updatePassword(user, newPassword, passwordEncoder);
+        redirectAttributes.addFlashAttribute("success", "Password changed successfully");
+        return "redirect:/admin/users";
+    }
+
+    @PostMapping("/updateOrderStatus")
+    public String updateOrderStatus(@RequestParam UUID orderId,
+                                    @RequestParam("status") OrderStatusEnum status) {
+        orderService.updateOrderStatus(orderId, status);
+        return "redirect:/admin/orders";
+    }
+
+    @GetMapping("/orders")
+    public String allOrders(Model model) {
+        List<OrderSummaryDto> orders = orderService.getAllOrderSummaries();
+        model.addAttribute("orders", orders);
+        return "admin/orders";
+    }
+}

--- a/src/main/java/com/example/pizzaapp/dtos/UserSummaryDto.java
+++ b/src/main/java/com/example/pizzaapp/dtos/UserSummaryDto.java
@@ -1,0 +1,14 @@
+package com.example.pizzaapp.dtos;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserSummaryDto {
+    private UUID id;
+    private String username;
+    private String role;
+}

--- a/src/main/java/com/example/pizzaapp/services/OrderService.java
+++ b/src/main/java/com/example/pizzaapp/services/OrderService.java
@@ -199,4 +199,13 @@ public class OrderService {
                 item.getSubtotal(),
                 toppingDtos);
     }
+
+    public void updateOrderStatus(UUID orderId, OrderStatus.OrderStatusEnum status) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+        OrderStatus newStatus = orderStatusRepository.findByCode(status)
+                .orElseThrow(() -> new IllegalArgumentException("Status not found"));
+        order.setStatus(newStatus);
+        orderRepository.save(order);
+    }
 }

--- a/src/main/java/com/example/pizzaapp/services/UserService.java
+++ b/src/main/java/com/example/pizzaapp/services/UserService.java
@@ -1,10 +1,16 @@
 package com.example.pizzaapp.services;
 
 import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.example.pizzaapp.dtos.UserSummaryDto;
+import com.example.pizzaapp.models.Role;
 import com.example.pizzaapp.models.User;
 import com.example.pizzaapp.repositories.UserRepository;
 
@@ -23,5 +29,33 @@ public class UserService {
 
     public User findUserByEmail(String email) {
         return userRepository.findByEmail(email).orElse(null);
+    }
+
+    public List<UserSummaryDto> getAllUserSummaries() {
+        return userRepository.findAll().stream()
+                .map(this::toSummaryDto)
+                .collect(Collectors.toList());
+    }
+
+    public User findById(UUID id) {
+        return userRepository.findById(id).orElse(null);
+    }
+
+    public void updatePassword(User user, String rawPassword, PasswordEncoder encoder) {
+        user.setPassword(encoder.encode(rawPassword));
+        userRepository.save(user);
+    }
+
+    public void deleteById(UUID id) {
+        userRepository.deleteById(id);
+    }
+
+    private UserSummaryDto toSummaryDto(User user) {
+        String role = user.getRoles().stream()
+                .map(Role::getName)
+                .findFirst()
+                .map(Enum::name)
+                .orElse("");
+        return new UserSummaryDto(user.getId(), user.getUsername(), role);
     }
 }

--- a/src/main/resources/templates/navbar/adminNavbar.html
+++ b/src/main/resources/templates/navbar/adminNavbar.html
@@ -1,0 +1,17 @@
+<nav th:fragment="navbar" class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/admin/dashboard">Admin</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNavbar" aria-controls="adminNavbar" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="adminNavbar">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="/admin/orders">Orders</a></li>
+                <li class="nav-item"><a class="nav-link" href="/admin/users">Users</a></li>
+            </ul>
+            <form th:action="@{/logout}" method="post" class="d-flex">
+                <button class="btn btn-outline-light" type="submit">Logout</button>
+            </form>
+        </div>
+    </div>
+</nav>


### PR DESCRIPTION
## Summary
- add an `AdminController` with user and order management endpoints
- add `UserSummaryDto` and extend `UserService`
- allow updating order status in `OrderService`
- restrict `/admin/**` routes to ADMIN role
- provide an admin navbar template

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864145e5a808326a557dbee2a54d7d4